### PR TITLE
refactor: Prepare application for split frontend/backend deployment

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "cookie-parser": "^1.4.7",
+        "cors": "^2.8.5",
         "express": "^5.1.0",
         "multer": "^2.0.2"
       },
@@ -282,6 +283,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/debug": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "cookie-parser": "^1.4.7",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "multer": "^2.0.2"
   },

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env*

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axios from 'axios';
+import api from './api/axios';
 import InputForm from './components/InputForm';
 import './App.css';
 
@@ -52,12 +52,10 @@ function App() {
     }
 
     try {
-      const response = await axios.post('/api/generate', data, {
+      const response = await api.post('/generate', data, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },
-        // The backend expects HTML, so let's set the responseType
-        // The spec says the backend will return text/html
         responseType: 'text',
       });
       setPresentationHtml(response.data);

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api',
+  withCredentials: true, // This is important for sending cookies
+});
+
+export default api;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useContext, useEffect } from 'react';
-import axios from 'axios';
+import api from '../api/axios';
 
 const AuthContext = createContext(null);
 
@@ -7,11 +7,10 @@ export const AuthProvider = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  // Check auth status on initial load
   useEffect(() => {
     const checkStatus = async () => {
       try {
-        await axios.get('/api/auth-status');
+        await api.get('/auth-status');
         setIsAuthenticated(true);
       } catch (error) {
         setIsAuthenticated(false);
@@ -24,7 +23,7 @@ export const AuthProvider = ({ children }) => {
 
   const login = async (password) => {
     try {
-      await axios.post('/api/login', { password });
+      await api.post('/login', { password });
       setIsAuthenticated(true);
       return true;
     } catch (error) {
@@ -34,7 +33,6 @@ export const AuthProvider = ({ children }) => {
   };
 
   const logout = () => {
-    // We would also call a /api/logout endpoint here
     setIsAuthenticated(false);
   };
 


### PR DESCRIPTION
This commit refactors the application to support a standard deployment model where the frontend and backend are hosted on separate services.

Backend changes:
- The Express server is now a standalone API server.
- The logic for serving the frontend static files has been removed.
- Added the `cors` middleware to allow cross-origin requests from the frontend domain.
- Updated cookie settings (`secure: true`, `sameSite: 'none'`) to support cross-domain authentication.

Frontend changes:
- The frontend now uses an environment variable (`VITE_API_BASE_URL`) to determine the backend API address.
- A centralized Axios instance has been created to manage API calls.
- `.env*` files have been added to `.gitignore`.